### PR TITLE
Create a Customize DatepickerDialog to Display Date in the Title

### DIFF
--- a/dailymoney/src/com/bottleworks/commons/util/GUIs.java
+++ b/dailymoney/src/com/bottleworks/commons/util/GUIs.java
@@ -21,6 +21,7 @@ import android.widget.DatePicker;
 import android.widget.Toast;
 
 import com.bottleworks.dailymoney.core.R;
+import com.bottleworks.dailymoney.ui.CustomizeDatePickerDialog;
 
 /**
  * 
@@ -292,17 +293,16 @@ public class GUIs {
     public static void openDatePicker(Context context, Date d,final OnFinishListener listener) {
         final Calendar c = Calendar.getInstance();
         c.setTime(d);
-        //for event
-        final DatePickerDialog[] s = new DatePickerDialog[1];
-        DatePickerDialog picker = new DatePickerDialog(context, new DatePickerDialog.OnDateSetListener(){
+        // for event
+        DatePickerDialog picker = new CustomizeDatePickerDialog(context, new DatePickerDialog.OnDateSetListener() {
             @Override
             public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
                 c.set(Calendar.YEAR,year);
                 c.set(Calendar.MONTH,monthOfYear);
                 c.set(Calendar.DAY_OF_MONTH,dayOfMonth);
                 listener.onFinish(c.getTime());
-            }}, c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH));
-        s[0] = picker;
+            }
+        }, c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH));
         picker.show();
     }
     
@@ -329,4 +329,5 @@ public class GUIs {
     public static boolean isLandscape(Activity activity){
         return activity.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
     }
+
 }

--- a/dailymoney/src/com/bottleworks/dailymoney/ui/CustomizeDatePickerDialog.java
+++ b/dailymoney/src/com/bottleworks/dailymoney/ui/CustomizeDatePickerDialog.java
@@ -1,0 +1,55 @@
+package com.bottleworks.dailymoney.ui;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import android.app.DatePickerDialog;
+import android.content.Context;
+import android.text.format.DateFormat;
+import android.widget.DatePicker;
+
+public class CustomizeDatePickerDialog extends DatePickerDialog {
+
+    private Calendar c;
+    private SimpleDateFormat sdf;
+
+    public CustomizeDatePickerDialog(Context context, OnDateSetListener callBack, int year, int monthOfYear, int dayOfMonth) {
+        super(context, 0, callBack, year, monthOfYear, dayOfMonth);
+        char[] order = DateFormat.getDateFormatOrder(context);
+        StringBuffer formatString = new StringBuffer();
+        for (char ch : order) {
+            switch (ch) {
+            case DateFormat.DATE:
+                formatString.append("-dd");
+                break;
+            case DateFormat.MONTH:
+                formatString.append("-MM");
+                break;
+            case DateFormat.YEAR:
+                formatString.append("-yyyy");
+                break;
+            }
+        }
+        formatString.append(" EEE").deleteCharAt(0);
+        sdf = new SimpleDateFormat(formatString.toString());
+        c = Calendar.getInstance();
+        updateTitle(year, monthOfYear, dayOfMonth);
+    }
+
+    @Override
+    public void onDateChanged(DatePicker view, int year, int month, int day) {
+        // To call super.onDateChanged will remove itself as DatePicker listener
+        // in 4.0
+        // super.onDateChanged(view, year, month, day);
+        view.init(year, month, day, this);
+        updateTitle(year, month, day);
+    }
+
+    private void updateTitle(int year, int month, int day) {
+        c.set(Calendar.YEAR, year);
+        c.set(Calendar.MONTH, month);
+        c.set(Calendar.DAY_OF_MONTH, day);
+        setTitle(sdf.format(c.getTime()));
+    }
+
+}


### PR DESCRIPTION
Because the native class DatePickerDialog in Android 4.0 shows "Set Date" in title rather than date information as before, create a new customize DatePickerDialog to display date in the title.

因為 Android 4.0 原生的 DatePickerDialog 只會在標題顯示「設定日期」，而不會顯示日期資訊，所以增加一個自訂的 DatePickerDialog 在標題顯示日期資訊。

Native DatePickerDialog before 4.0
![01](https://lh5.googleusercontent.com/-FL7PwCsc_s4/T9b6wM3mvnI/AAAAAAAAMj4/WNun0WlPYas/s800/20120612_003.JPG)

Native DatePickerDialog after 4.0
![02](https://lh3.googleusercontent.com/-rSfmRiUz0BM/T9b67hFmp0I/AAAAAAAAMkA/Xvkwxi2FQJU/s800/20120612_002.JPG)

Customize DatePickerDialog (both before and after 4.0)
![03](https://lh4.googleusercontent.com/-8gEpqIc43zo/T9b7Hu5LQkI/AAAAAAAAMkI/_rnCK4GAkhg/s800/20120612_001.JPG)
